### PR TITLE
refactor skills section

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -469,6 +469,41 @@ img{
     row-gap: 0;
 }
 
+
+/*============= Box Skills ===================*/
+
+.skills__box__data {
+  text-align: center;
+}
+
+.skills__box__info {
+  display: grid;
+  justify-content: center;
+  grid-template-columns: repeat(3, 1fr);
+  gap: .5rem;
+  margin-bottom: 2rem;
+}
+.skills__box__box {
+  background-color: var(--container-color);
+  border-radius: .75rem;
+  padding: .75rem .5rem;
+  box-shadow: 0 2px 16px hsla(var(--second-hue), 48%, 8%, 0.1) ;
+}
+
+.skills__box__icon {
+  font-size: 1.5rem;
+  color: var(--first-color);
+  margin-bottom: .5rem;    
+}
+
+.skills__box__subtitle {
+  font-size: var(--smaller-font-size);
+}
+
+.skills__box__description {
+  margin-bottom: 2rem;
+}
+
 .skills__header{
     display: flex;
     align-items: center;
@@ -1067,6 +1102,23 @@ img{
   }
 
 /*==================== MEDIA QUERIES ====================*/
+/* For tiny devices (layout for skills cards) */
+@media screen and (min-width: 350px){
+  .skills__box__info {
+    justify-content: center;
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .skills__box__box {
+    column-gap: 1rem;
+  }
+
+  .skills__title{
+      font-size: var(--normal-font-size);
+  }
+
+
+}
 /* For small devices */
 @media screen and (max-width: 350px){
     .container{
@@ -1089,10 +1141,15 @@ img{
         width: 180px;
     }
 
-    .skills__title{
-        font-size: var(--normal-font-size);
-    }
+  .skills__box__info {
+    justify-content: center;
+    grid-template-columns: repeat(1, 1fr);
+  }
 
+.skills__box__box {
+    column-gap: 1rem;
+  }    
+    
     .qualification__data{
         gap: .5rem;
     }
@@ -1132,6 +1189,17 @@ img{
     .footer__container{
         grid-template-columns: repeat(2, 1fr);
     }
+
+    
+    .skills__box__info {
+      grid-template-columns: repeat(4, 140px);
+      justify-content: center;
+  }
+
+  .skills__box__description {
+      padding: 0 5rem;
+  }
+
 
     .qualification__sections{
         display: grid;
@@ -1206,6 +1274,27 @@ img{
     .home__scroll-button{
         margin-left: 3rem;
     }
+
+    .skills__box__data {
+      text-align: initial;
+  }
+
+  .skills__box__info {
+      justify-content: center;
+      grid-auto-columns: max-content;
+  }
+
+  .skills__box__box {
+      text-align: center;
+      padding: 1rem 1.25rem;
+  }
+
+  .skills__box__description {
+      padding: 0 4rem 0 0;
+      margin-bottom: 2.5rem;
+  }
+
+
 
     .about__container{
         column-gap: 5rem;
@@ -1303,6 +1392,12 @@ img{
     .home__social{
         transform: translateX(-6rem);
     }
+
+    
+  .skills__box__info {
+    justify-content: center;
+}
+
 
     .services__container{
         grid-template-columns: repeat(3, 238px);

--- a/index.html
+++ b/index.html
@@ -274,7 +274,6 @@
             <span class="section__subtitle">My technical level</span>
 
             <div class="skills__container container grid">
-                <div>
                     <!--====================== SKILLS 1 =============================-->
                     <div class="skills__content skills__open">
                         <div class="skills__header">
@@ -282,56 +281,39 @@
 
                             <div>
                                 <h1 class="skills__title">Software Development</h1>
-                                <span class="skills__subtitle">More than 2 years (University)</span>
+                                <span class="skills__subtitle">Developer Skills</span>
                             </div>
 
                             <i class="uil uil-angle-down skills__arrow"></i>
                         </div>
 
                         <div class="skills__list grid">
-                            <div class="skills__data">
-                                <div class="skills__titles">
-                                    <h3 class="skills__name">C++</h3>
-                                    <div class="skills__number">Intermediate<!--was 85%--></div>
-                                </div>
-                                <div class="skills__bar">
-                                    <div class="skills__percentage skills__cpp"></div>
-                                </div>
-                            </div>
-                        </div>
+                            <div class="skills__box__data">
+                                <div class="skills__box__info">
+            
+                                    <div class="skills__box__box">
+                                        <i class='il uil-code-branch skills__box__icon'></i>
+                                        <h3 class="skills__box__title">C++</h3>
+                                        <span class="skills__box__subtitle">Development</span>
+                                    </div>
+            
+                                    <div class="skills__box__box">
+                                        <i class='il uil-desktop skills__box__icon'></i>
+                                        <h3 class="about__title">Qt QML</h3>
+                                        <span class="skills__box__subtitle">Front-End</span>
+                                    </div>
 
-                        <div class="skills__list grid">
-                            <div class="skills__data">
-                                <div class="skills__titles">
-                                    <h3 class="skills__name">QT QML</h3>
-                                    <div class="skills__number">Advanced <!--was 50%--></div>
-                                </div>
-                                <div class="skills__bar">
-                                    <div class="skills__percentage skills__qml"></div>
-                                </div>
-                            </div>
-                        </div>
-
-                        <div class="skills__list grid">
-                            <div class="skills__data">
-                                <div class="skills__titles">
-                                    <h3 class="skills__name">SQL</h3>
-                                    <div class="skills__number">novice<!--was 85%--></div>
-                                </div>
-                                <div class="skills__bar">
-                                    <div class="skills__percentage skills__linux"></div>
-                                </div>
-                            </div>
-                        </div>
-
-                        <div class="skills__list grid">
-                            <div class="skills__data">
-                                <div class="skills__titles">
-                                    <h3 class="skills__name">Databases: Design & Implementation</h3>
-                                    <div class="skills__number">Novice<!--was 85%--></div>
-                                </div>
-                                <div class="skills__bar">
-                                    <div class="skills__percentage skills__python"></div>
+                                    <div class="skills__box__box">
+                                        <i class='il uil-database skills__box__icon'></i>
+                                        <h3 class="skills__box__title">MySQL</h3>
+                                        <span class="skills__box__subtitle">Databases</span>
+                                    </div>
+            
+                                    <div class="skills__box__box">
+                                        <i class='il uil-database skills__box__icon'></i>
+                                        <h3 class="skills__box__title">Databases </h3>
+                                        <span class="skills__box__subtitle">Design</span>
+                                    </div>
                                 </div>
                             </div>
                         </div>
@@ -345,37 +327,37 @@
 
                                 <div>
                                     <h1 class="skills__title">Other Technical Skills</h1>
-                                    <span class="skills__subtitle">All other notable skills </span>
+                                    <span class="skills__subtitle">Other notable skills </span>
                                 </div>
 
                                 <i class="uil uil-angle-down skills__arrow"></i>
                             </div>
 
                             <div class="skills__list grid">
-                                <div class="skills__data">
-                                    <div class="skills__titles">
-                                        <h3 class="skills__name">Linux</h3>
-                                        <div class="skills__number">novice<!--was 85%--></div>
+                                <div class="skills__box__data">
+                                    <div class="skills__box__info">
+                
+                
+                                        <!--=============== OTHER TECHNICAL SKILLS ===============-->
+                                        <div class="skills__box__box">
+                                            <i class='il uil-object-group skills__box__icon'></i>
+                                            <h3 class="skills__box__title">Figma </h3>
+                                            <span class="skills__box__subtitle">Design</span>
+                                        </div>
+                
+                                        <div class="skills__box__box">
+                                            <i class='il uil-linux skills__box__icon'></i>
+                                            <h3 class="skills__box__title">Linux </h3>
+                                            <span class="skills__box__subtitle">Ubuntu</span>
+                                        </div>
                                     </div>
-                                    <div class="skills__bar">
-                                        <div class="skills__percentage skills__linux"></div>
-                                    </div>
+                
+                
+                
                                 </div>
-                            </div>
-                            <div class="skills__list grid">
-                                <div class="skills__data">
-                                    <div class="skills__titles">
-                                        <h3 class="skills__name">Figma</h3>
-                                        <div class="skills__number">Intermediate <!--was 50%--></div>
-                                    </div>
-                                    <div class="skills__bar">
-                                        <div class="skills__percentage skills__qml"></div>
-                                    </div>
                                 </div>
-                            </div>
                         </div>
                     </div>
-                </div>
             </div>
         </section>
 


### PR DESCRIPTION
Removed old skill section that displayed progress bars, added cards that show the skill instead. However the CSS of the old skill section, that is, the skill containers & progress bars still remain. JS was not used for old Skill section nor for the new one.

resolves #32 
closes #32 